### PR TITLE
vcredist: use unique file names for 32-bit and 64-bit installers

### DIFF
--- a/vcredist2015/tools/chocolateyInstall.ps1
+++ b/vcredist2015/tools/chocolateyInstall.ps1
@@ -31,7 +31,7 @@ Install-ChocolateyPackage -PackageName "$packageName" `
 
 if (Get-ProcessorBits 64) {
 	Write-Verbose "Install also 32bit version on 64bit operation system."
-  Install-ChocolateyPackage -PackageName "$packageName" `
+  Install-ChocolateyPackage -PackageName "${packageName}_x86" `
                             -FileType "$installerType" `
                             -Url "$url" `
                             -SilentArgs "$silentArgs" `


### PR DESCRIPTION
On a clean Windows 8.1 x64 virtual machine, running on rather old hardware
and with quite limited resources (i.e. slow), I have observed the
following behavior while installing vcredist2013(*):
1) Chocolatey downloads and installs the 64-bit version successfully
2) Chocolatey proceeds to download the installer for the 32-bit version,
   using the same local file name as for the 64-bit version
   (vcredist2013Install.exe).
3) The download fails, because the destination file is used by
   another process.

I believe this happens because, due to the slowness of the machine,
although the 64-bit vcredist installation has finished from Chocolatey
point of view, a system component (the Windows Installer service?) is
still holding the installer file open for a brief amount of time. This is
definitely a timing-related issue, because I have not been able to
reproduce it on an identical VM running on better hardware with more
resources.

Since the local installer file name is determined by the packageName
argument to Install-ChocolateyPackage, let's avoid the problem by using a
different name for the 32-bit installer on 64-bit OS.

(*) Although I personally encountered the issue while installing the 2013
redist, it could happen for all other redists, too.
