### PR TITLE
vcredist2015: add dependency on KB2919355 package

### DIFF
--- a/vcredist2015/vcredist2015.nuspec
+++ b/vcredist2015/vcredist2015.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
 		<id>vcredist2015</id>
-		<version>14.0.24212.0</version>
+		<version>14.0.24212.20160818</version>
 		<title>Visual C++ Redistributable for Visual Studio 2015</title>
 		<authors>Microsoft</authors>
 		<owners>pocki_c</owners>
@@ -20,8 +20,14 @@
 * Date published by Microsoft: 30/03/2016
 * Supported Operating Systems: Windows 10 , Windows 7 Service Pack 1, Windows 8, Windows 8.1, Windows Server 2003 Service Pack 2, Windows Server 2008 R2 SP1, Windows Server 2008 Service Pack 2, Windows Server 2012, Windows Vista Service Pack 2, Windows XP Service Pack 3
 * Known issues: http://go.microsoft.com/fwlink/?LinkId=613260
+
+#### Package
+* added dependency on KB2919355
 		</releaseNotes>
 		<copyright>http://www.microsoft.com/about/legal/en/us/IntellectualProperty/Copyright/Default.aspx</copyright>
 		<tags>visual c++ redistributable 2015 studio admin</tags>
+		<dependencies>
+			<dependency id="KB2919355" version="1.0.20160719" />
+		</dependencies>
 	</metadata>
 </package>


### PR DESCRIPTION
Now that there is an actual Chocolatey package for KB2919355, vcredist2015 should depend on it.
